### PR TITLE
Adds baseUri to ExportController

### DIFF
--- a/app/library/App/Bootstrap/RouteBootstrap.php
+++ b/app/library/App/Bootstrap/RouteBootstrap.php
@@ -36,7 +36,7 @@ class RouteBootstrap implements BootstrapInterface
 
             $view->setVar('title', $config->application->title);
             $view->setVar('description', $config->application->description);
-            $view->setVar('documentationPath', $config->hostName . '/export/documentation.json');
+            $view->setVar('documentationPath', $config->hostName . $config->application->baseUri . '/export/documentation.json');
             return $view->render('general/documentation');
         });
     }

--- a/app/library/App/Controllers/ExportController.php
+++ b/app/library/App/Controllers/ExportController.php
@@ -16,7 +16,7 @@ class ExportController extends CollectionController
         /** @var \Phalcon\Config $config */
         $config = $this->di->get(Services::CONFIG);
 
-        $documentation = new Documentation($config->application->title, $config->hostName);
+        $documentation = new Documentation($config->application->title, $config->hostName . $config->application->baseUri);
         $documentation->addManyCollections($this->application->getCollections());
         $documentation->addManyRoutes($this->application->getRouter()->getRoutes());
 
@@ -28,7 +28,7 @@ class ExportController extends CollectionController
         /** @var \Phalcon\Config $config */
         $config = $this->di->get(Services::CONFIG);
 
-        $postmanCollection = new ApiCollection($config->application->title, $config->hostName);
+        $postmanCollection = new ApiCollection($config->application->title, $config->hostName . $config->application->baseUri);
         $postmanCollection->addManyCollections($this->application->getCollections());
         $postmanCollection->addManyRoutes($this->application->getRouter()->getRoutes());
 


### PR DESCRIPTION
Hi! First of all, thanks for the great projects!

When I configure the `baseUri` other than `/`
- the `documentation.html` endpoint aware of the configuration, but it makes bad request for the `documentation.json` (the url does not contain the baseUri)
- likewise the `export/postman.json` endpoint is accessible, but the JSON data's `url` field does not contain the baseUri. 

Updated the PR with modification in `RouteBootstrap`.
